### PR TITLE
Fix width and height of use image

### DIFF
--- a/src/components/image-labeller/UseImageContainer.ts
+++ b/src/components/image-labeller/UseImageContainer.ts
@@ -21,16 +21,19 @@ function useImageContainer(image: HTMLImageElement): useImageContainerReturns {
   }
 
   let width, height, scale: number;
-  if (image.naturalWidth >= image.naturalHeight) {
-    const ratio = image.naturalWidth / image.naturalHeight;
-    width = containerWidth;
-    height = containerWidth / ratio;
-    scale = width / image.naturalWidth;
-  } else {
-    const ratio = image.naturalHeight / image.naturalWidth;
+
+  const naturalRatio = image.naturalWidth / image.naturalHeight;
+  const widthRatio = containerWidth / image.naturalWidth;
+  const heightRatio = containerHeight / image.naturalHeight;
+
+  if (widthRatio > heightRatio) {
+    width = containerHeight * naturalRatio;
     height = containerHeight;
-    width = containerHeight / ratio;
     scale = height / image.naturalHeight;
+  } else {
+    width = containerWidth;
+    height = containerWidth / naturalRatio;
+    scale = width / image.naturalWidth;
   }
 
   const dimensions = { width, height };


### PR DESCRIPTION
Images should now be sized to fit into the labeller container.

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/e1c245fb-c5b6-4489-a766-b8b304567bd9) | ![image](https://github.com/user-attachments/assets/214a6035-d996-431d-b59e-c63a5b2e73fb)
